### PR TITLE
Fix peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "cross-env": "^5.2.0"
   },
   "peerDependencies": {
-    "react": "^15.3.0|^16.14.0",
-    "react-dom": "^15.3.0|^16.14.0"
+    "react": ">=15.3.0",
+    "react-dom": ">=15.3.0"
   }
 }


### PR DESCRIPTION
Peer dependencies should be set with >= to be compatible with further update of react versions.

Actually current version of react-bytesize-icons cannot be installed with actual react version
bacause of `^16.14.0` is not compatible with `react@18.2.0`.

With this commit it works fine.